### PR TITLE
fix: work with deploy/netlify branch and existing

### DIFF
--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -1,3 +1,4 @@
+/* eslint import/first: "off" */
 jest.mock('@octokit/rest', () => {
   class Octokit {
     constructor() {
@@ -64,6 +65,7 @@ test('it calls console.log with deployed url', async () => {
 })
 
 test('it works with deploy/netlify status', async () => {
+  /* eslint-disable camelcase */
   const target_url = `https://deploy-preview-26--something-different.netlify.com`
   const combinedStatusResponseWithChangedContext = {
     ...combinedStatusResponse,

--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -65,8 +65,7 @@ test('it calls console.log with deployed url', async () => {
 })
 
 test('it works with deploy/netlify status', async () => {
-  /* eslint-disable camelcase */
-  const target_url = `https://deploy-preview-26--something-different.netlify.com`
+  const targetUrl = `https://deploy-preview-26--something-different.netlify.com`
   const combinedStatusResponseWithChangedContext = {
     ...combinedStatusResponse,
     repository: {
@@ -77,7 +76,7 @@ test('it works with deploy/netlify status', async () => {
       {
         ...combinedStatusResponse.statuses[0],
         context: 'deploy/netlify',
-        target_url
+        target_url: targetUrl
       }
     ]
   }
@@ -91,6 +90,6 @@ test('it works with deploy/netlify status', async () => {
   await pWaitFor(() => consola.log.mock.calls.length > 0)
 
   expect(consola.log).toHaveBeenCalledWith(
-    expect.stringContaining(target_url)
+    expect.stringContaining(targetUrl)
   )
 })

--- a/main.js
+++ b/main.js
@@ -20,13 +20,13 @@ const octokit = new Octokit({
 const [owner, repo] = process.env.TRAVIS_REPO_SLUG.split('/')
 const ref = process.env.TRAVIS_PULL_REQUEST_SHA
 
-const hasDeployPreview = context => /^netlify\/.*\/deploy-preview$/.test(context)
+const hasDeployPreview = context => [/^netlify\/.*\/deploy-preview$/, /^deploy\/netlify$/].some(expr => expr.test(context))
 const successPreview = state => state === 'success'
 const failedPreview = state => state === 'failure'
 
 const getSuccessfulDeployment = async () => {
   const { data: { statuses } } = await octokit.repos.getCombinedStatusForRef({ owner, ref, repo })
-
+  
   if (statuses.find(({ context, state }) => hasDeployPreview(context) && failedPreview(state))) {
     consola.error('Deploy preview failed')
     // Fail CI
@@ -37,7 +37,6 @@ const getSuccessfulDeployment = async () => {
 }
 
 const deployed = async () => Boolean(await getSuccessfulDeployment())
-
 ;(async () => {
   await pWaitFor(deployed, { interval: 15000 })
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "eslint-plugin-standard": "^4.0.0",
     "eslint-plugin-vue": "^5.1.0",
     "jest": "^24.1.0",
-    "nock": "^10.0.6",
     "standard-version": "^4.4.0"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "repository": "Developmint/wait-for-netlify-preview",
   "scripts": {
     "lint": "eslint index.js __test__",
-    "test": "yarn run lint && jest --detectOpenHandles",
+    "pretest": "yarn run lint",
+    "test": "jest --detectOpenHandles",
     "release": "standard-version && git push --follow-tags && npm publish",
     "commitlint": "commitlint -E HUSKY_GIT_PARAMS",
     "coverage": "codecov"

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,11 +928,6 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
-assertion-error@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
-  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
-
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -1281,18 +1276,6 @@ caseless@~0.12.0:
   resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chai@^4.1.2:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
-  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
-  dependencies:
-    assertion-error "^1.1.0"
-    check-error "^1.0.2"
-    deep-eql "^3.0.1"
-    get-func-name "^2.0.0"
-    pathval "^1.1.0"
-    type-detect "^4.0.5"
-
 chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1317,11 +1300,6 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
-
-check-error@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
-  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 chownr@^1.1.1:
   version "1.1.1"
@@ -2025,18 +2003,6 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
-
-deep-eql@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
-  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
-  dependencies:
-    type-detect "^4.0.0"
-
-deep-equal@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -2837,11 +2803,6 @@ get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
-
-get-func-name@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
-  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
 get-pkg-repo@^1.0.0:
   version "1.4.0"
@@ -4584,21 +4545,6 @@ nice-try@^1.0.4:
   resolved "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-nock@^10.0.6:
-  version "10.0.6"
-  resolved "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz#e6d90ee7a68b8cfc2ab7f6127e7d99aa7d13d111"
-  integrity sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==
-  dependencies:
-    chai "^4.1.2"
-    debug "^4.1.0"
-    deep-equal "^1.0.0"
-    json-stringify-safe "^5.0.1"
-    lodash "^4.17.5"
-    mkdirp "^0.5.0"
-    propagate "^1.0.0"
-    qs "^6.5.1"
-    semver "^5.5.0"
-
 node-fetch@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
@@ -5074,11 +5020,6 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
-pathval@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
-  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -5540,11 +5481,6 @@ prompts@^2.0.1:
     kleur "^3.0.0"
     sisteransi "^1.0.0"
 
-propagate@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
-  integrity sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=
-
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -5577,11 +5513,6 @@ q@^1.1.2, q@^1.4.1, q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
-
-qs@^6.5.1:
-  version "6.6.0"
-  resolved "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
-  integrity sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==
 
 qs@~6.5.2:
   version "6.5.2"
@@ -6745,11 +6676,6 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
-
-type-detect@^4.0.0, type-detect@^4.0.5:
-  version "4.0.8"
-  resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
-  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
Whew - this was kind of a doozy to get the unit tests passing.

## Description

This PR introduces a fix for working on the newer (?) status check descriptions that Netlify exposes.

For example, if we check out the [following repo](https://github.com/amberleyromo/dotme/pull/1) we can see that the deploy preview status check is actually named `deploy/netlify` which will fail the regular expression `/^netlify\/.*\/deploy-preview$/`.

This fixes this issue, while remaining backwards compatible.

Additionally, I added a test and tweaked the existing tests to complete a little more quickly.

- Removes `nock` and just mocks `octokit/rest` directly
- Ensures that `main.js` is required _new_ each test (`jest.isolateModules`)
- Tweaks assertions slightly for consola.log statements

Let me know if you have any questions!

## Related

Fixes #14

cc @amberleyromo